### PR TITLE
chore: fix build error with elasticsearch 9.0.0

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <description>Pinyin Analysis for Elasticsearch</description>
     <packaging>jar</packaging>
     <properties>
-        <elasticsearch.version>8.16.1</elasticsearch.version>
+        <elasticsearch.version>9.0.0</elasticsearch.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!--<elasticsearch.assembly.descriptor>${basedir}/src/main/assemblies/plugin.xml</elasticsearch.assembly.descriptor>-->
         <plugin.name>analysis-pinyin</plugin.name>

--- a/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinAbbreviationsTokenizerFactory.java
+++ b/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinAbbreviationsTokenizerFactory.java
@@ -11,7 +11,7 @@ import org.elasticsearch.index.analysis.AbstractTokenizerFactory;
 public class PinyinAbbreviationsTokenizerFactory extends AbstractTokenizerFactory {
 
     public PinyinAbbreviationsTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, settings, name);
+        super(name);
     }
 
     @Override

--- a/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinAnalyzerProvider.java
+++ b/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinAnalyzerProvider.java
@@ -9,7 +9,8 @@ import org.elasticsearch.index.analysis.AbstractIndexAnalyzerProvider;
 import org.elasticsearch.injection.api.Inject;
 
 
-/**
+/*
+ * Provider for the PinyinAnalyzer.
  */
 public class PinyinAnalyzerProvider extends AbstractIndexAnalyzerProvider<PinyinAnalyzer> {
 
@@ -18,7 +19,7 @@ public class PinyinAnalyzerProvider extends AbstractIndexAnalyzerProvider<Pinyin
 
     @Inject
     public PinyinAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(name, settings);
+        super(name);
         config=new ESPinyinConfig(settings);
         analyzer = new PinyinAnalyzer(config);
     }

--- a/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinTokenFilterFactory.java
+++ b/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinTokenFilterFactory.java
@@ -14,7 +14,7 @@ public class PinyinTokenFilterFactory extends AbstractTokenFilterFactory {
 
 
     public PinyinTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(name, settings);
+        super(name);
        config=new ESPinyinConfig(settings);
     }
 

--- a/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinTokenizerFactory.java
+++ b/elasticsearch/src/main/java/com/infinilabs/elasticsearch/analysis/PinyinTokenizerFactory.java
@@ -13,7 +13,7 @@ public class PinyinTokenizerFactory extends AbstractTokenizerFactory {
     private PinyinConfig config;
 
     public PinyinTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, settings, name);
+        super(name);
         config=new ESPinyinConfig(settings);
     }
 


### PR DESCRIPTION
This pull request updates the Elasticsearch plugin to be compatible with version 9.0.0 and simplifies constructors across several factory classes. The most important changes include upgrading the Elasticsearch version in the `pom.xml` file and modifying constructors to remove unused parameters for consistency and maintainability.

### Elasticsearch version upgrade:
* [`elasticsearch/pom.xml`](diffhunk://#diff-711f6a020d711eb56669ab5f5cca0f182c3bfe222d087bee6230e596e4f7174dL17-R17): Updated the Elasticsearch version from `8.16.1` to `9.0.0` to ensure compatibility with the latest version.

### Constructor simplifications:
* [`PinyinAbbreviationsTokenizerFactory.java`](diffhunk://#diff-9e575ae254c52d839e25618f38e8b3794a8d310321401f57d4fa145e753b944cL14-R14): Simplified the constructor by removing the `indexSettings` and `settings` parameters, retaining only the `name` parameter.
* [`PinyinAnalyzerProvider.java`](diffhunk://#diff-6ff0005ec9c3ed7ec73112cf9695e22121c1041f6bf1c406fe384d90aa169170L21-R22): Updated the constructor to remove the `settings` parameter from the superclass call, keeping only the `name` parameter.
* [`PinyinTokenFilterFactory.java`](diffhunk://#diff-f1b941499b3151184ee152b7273fea838745e3c613128b2a3421a684d68acc83L17-R17): Simplified the constructor by removing the `settings` parameter from the superclass call, while maintaining the `name` parameter.
* [`PinyinTokenizerFactory.java`](diffhunk://#diff-30e1e62fc2bf517458112b1916995bf74368072035e1da74856b8a87728197a5L16-R16): Adjusted the constructor to remove the `indexSettings` and `settings` parameters, only passing the `name` parameter to the superclass.

### Documentation improvement:
* [`PinyinAnalyzerProvider.java`](diffhunk://#diff-6ff0005ec9c3ed7ec73112cf9695e22121c1041f6bf1c406fe384d90aa169170L12-R13): Replaced the `/**` Javadoc comment with a standard block comment `/*` for consistency.